### PR TITLE
decoupled from depending on exphbs.compileTemplate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-secure-handlebars",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "licenses": [
     {
       "type": "BSD",
@@ -32,10 +32,10 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "util": "^0.10.*",
-    "debug": "^2.1.*",
     "context-parser-handlebars": "^1.0.5",
     "express-handlebars": "^1.2.*",
+    "handlebars": "^3.0.0",
+    "util": "^0.10.*",
     "xss-filters": "^1.*"
   },
   "devDependencies": {

--- a/src/express-secure-handlebars.js
+++ b/src/express-secure-handlebars.js
@@ -9,67 +9,21 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 */
 /*jshint -W030 */
 var util = require("util"),
-    debug = require('debug')('esh'),
     expressHandlebars = require('express-handlebars').ExpressHandlebars,
-    xssFilters = require('xss-filters'),
-    privateFilters = xssFilters._privFilters,
-    ContextParserHandlebars = require("context-parser-handlebars");
+    secureHandlebars = require('./secure-handlebars');
 
 function ExpressSecureHandlebars(config) {
 
+    // override the original handlebars with secure-handlebars
+    config || (config = {});
+    config.handlebars = config.secureHandlebars || secureHandlebars;
+
     /* calling super constructor */
     this.constructor.super_.call(this, config);
-
-    if (this.handlebars.helpers) {
-        var h = this.handlebars;
-        // register below the filters that are automatically applied by context parser 
-        [
-            'y',
-            'yd', 'yc', 
-            'yavd', 'yavs', 'yavu',
-            'yu', 'yuc',
-            'yubl', 'yufull'
-        ].forEach(function(filterName){
-            h.registerHelper(filterName, privateFilters[filterName]);
-        });
-        // register below the filters that might be manually applied by developers
-        [
-            'inHTMLData', 'inHTMLComment',
-            'inSingleQuotedAttr', 'inDoubleQuotedAttr', 'inUnQuotedAttr',
-            'uriInSingleQuotedAttr', 'uriInDoubleQuotedAttr', 'uriInUnQuotedAttr', 'uriInHTMLData', 'uriInHTMLComment',
-            'uriPathInSingleQuotedAttr', 'uriPathInDoubleQuotedAttr', 'uriPathInUnQuotedAttr', 'uriPathInHTMLData', 'uriPathInHTMLComment',
-            'uriQueryInSingleQuotedAttr', 'uriQueryInDoubleQuotedAttr', 'uriQueryInUnQuotedAttr', 'uriQueryInHTMLData', 'uriQueryInHTMLComment',
-            'uriComponentInSingleQuotedAttr', 'uriComponentInDoubleQuotedAttr', 'uriComponentInUnQuotedAttr', 'uriComponentInHTMLData', 'uriComponentInHTMLComment',
-            'uriFragmentInSingleQuotedAttr', 'uriFragmentInDoubleQuotedAttr', 'uriFragmentInUnQuotedAttr', 'uriFragmentInHTMLData', 'uriFragmentInHTMLComment'
-        ].forEach(function(filterName){
-            h.registerHelper(filterName, xssFilters[filterName]);
-        });
-        debug(h.helpers);
-    }
 }
 
 /* inheriting the express-handlebars */
 util.inherits(ExpressSecureHandlebars, expressHandlebars);
-
-ExpressSecureHandlebars.prototype.compileTemplate = function (template, options) {
-    if (!options || !options.precompiled) {
-        try {
-            var parser = new ContextParserHandlebars({printCharEnable: false});
-            parser.contextualize(template);
-            template = parser.getOutput();
-        } catch (err) {
-            console.log('=====================');
-            console.log("[WARNING] ExpressSecureHandlebars: falling back to the original express-handlebars");
-            Object.keys(err).forEach(function(k){console.log(k.toUpperCase() + ':\n' + err[k]);});
-            console.log("TEMPLATE:\n" + template);
-            console.log('=====================');
-        }
-    } else {
-        console.log("[WARNING] ExpressSecureHandlebars: ContextParserHandlebars cannot handle precompiled template!");
-    }
-
-    return ExpressSecureHandlebars.super_.prototype.compileTemplate.call(this, template, options);
-};
 
 /* exporting the same signature of express-handlebars */
 exports = module.exports  = exphbs;

--- a/src/secure-handlebars.js
+++ b/src/secure-handlebars.js
@@ -1,0 +1,80 @@
+/* 
+Copyright (c) 2015, Yahoo Inc. All rights reserved.
+Copyrights licensed under the New BSD License.
+See the accompanying LICENSE file for terms.
+
+Authors: Nera Liu <neraliu@yahoo-inc.com>
+         Albert Yu <albertyu@yahoo-inc.com>
+         Adonis Fung <adon@yahoo-inc.com>
+*/
+/*jshint -W030 */
+var Handlebars = require('handlebars'),
+    ContextParserHandlebars = require("context-parser-handlebars"),
+    xssFilters = require('xss-filters');
+
+
+
+function preprocess(template) {
+    try {
+        if (template) {
+            var parser = new ContextParserHandlebars({printCharEnable: false});
+            parser.contextualize(template);
+            return parser.getOutput();
+        }
+    } catch (err) {
+        console.log('=====================');
+        console.log("[WARNING] SecureHandlebars: falling back to the original template");
+        Object.keys(err).forEach(function(k){console.log(k.toUpperCase() + ':\n' + err[k]);});
+        console.log("TEMPLATE:\n" + template);
+        console.log('=====================');
+    }
+    return template;
+}
+
+function override(h) {
+    var c = h.compile, 
+        pc = h.precompile,
+        privateFilters = xssFilters._privFilters;
+
+    // override precompile function to preprocess the template first
+    h.precompile = function (template, options) {
+        return pc.call(this, preprocess(template), options);
+    };
+
+    // override compile function to preprocess the template first
+    h.compile = function (template, options) {
+        return c.call(this, preprocess(template), options);
+    };
+
+    // register below the filters that are automatically applied by context parser 
+    [
+        'y',
+        'yd', 'yc', 
+        'yavd', 'yavs', 'yavu',
+        'yu', 'yuc',
+        'yubl', 'yufull'
+    ].forEach(function(filterName){
+        h.registerHelper(filterName, privateFilters[filterName]);
+    });
+
+    // register below the filters that might be manually applied by developers
+    [
+        'inHTMLData', 'inHTMLComment',
+        'inSingleQuotedAttr', 'inDoubleQuotedAttr', 'inUnQuotedAttr',
+        'uriInSingleQuotedAttr', 'uriInDoubleQuotedAttr', 'uriInUnQuotedAttr', 'uriInHTMLData', 'uriInHTMLComment',
+        'uriPathInSingleQuotedAttr', 'uriPathInDoubleQuotedAttr', 'uriPathInUnQuotedAttr', 'uriPathInHTMLData', 'uriPathInHTMLComment',
+        'uriQueryInSingleQuotedAttr', 'uriQueryInDoubleQuotedAttr', 'uriQueryInUnQuotedAttr', 'uriQueryInHTMLData', 'uriQueryInHTMLComment',
+        'uriComponentInSingleQuotedAttr', 'uriComponentInDoubleQuotedAttr', 'uriComponentInUnQuotedAttr', 'uriComponentInHTMLData', 'uriComponentInHTMLComment',
+        'uriFragmentInSingleQuotedAttr', 'uriFragmentInDoubleQuotedAttr', 'uriFragmentInUnQuotedAttr', 'uriFragmentInHTMLData', 'uriFragmentInHTMLComment'
+    ].forEach(function(filterName){
+        h.registerHelper(filterName, xssFilters[filterName]);
+    });
+    return h;
+}
+
+
+if (module && module.exports) {
+    module.exports = override(Handlebars.create());
+} else { 
+    override(Handlebars);
+}

--- a/tests/unit/run-express-secure-handlebars.js
+++ b/tests/unit/run-express-secure-handlebars.js
@@ -12,18 +12,18 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
     require("mocha");
     var expect = require('expect.js'),
         expressHandlebars = require('express-handlebars'),
-        expressSecureHandlebars = require('../../src/express-secure-handlebars.js');
+        expressSecureHandlebars = require('../../src/express-secure-handlebars.js'),
+        handlebars = require('handlebars');
 
     describe("Express Secure Handlebars test suite", function() {
 
-        it("Express Secure Handlebars same signature test", function() {
+        it("same signature test", function() {
             // console.log(expressHandlebars);
             expect(typeof expressHandlebars).to.be.equal('function');
             expect(typeof expressHandlebars.create).to.be.equal('function');
             expect(typeof expressHandlebars.ExpressHandlebars).to.be.equal('function');
             expect(expressHandlebars.create).to.be.ok();
             expect(expressHandlebars.ExpressHandlebars).to.be.ok();
-            expect(expressHandlebars.create().compileTemplate).to.be.ok();
 
 
             // console.log(expressSecureHandlebars);
@@ -32,17 +32,16 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(typeof expressSecureHandlebars.ExpressHandlebars).to.be.equal('function');
             expect(expressSecureHandlebars.create).to.be.ok();
             expect(expressSecureHandlebars.ExpressHandlebars).to.be.ok();
-            expect(expressSecureHandlebars.create().compileTemplate).to.be.ok();
         });
 
-        it("Express Secure Handlebars new instance test", function() {
+        it("new instance test", function() {
             var expHbs = new expressHandlebars();
             expect(typeof expHbs).to.be.equal('function');
             var expSecureHbs = new expressSecureHandlebars();
             expect(typeof expSecureHbs).to.be.equal('function');
         });
 
-        it("Express Secure Handlebars create() new instance with handlebars test", function() {
+        it("create() new instance with handlebars test", function() {
             var expHbs = expressHandlebars.create();
             expect(expHbs.handlebars).to.be.ok();
             var expSecureHbs = expressSecureHandlebars.create();
@@ -50,23 +49,33 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
         });
 
         var data = {url: 'javascript:alert(1)'};
-        it("Express Secure Handlebars fallback on error test", function() {
-            var template = '{{#if url}}<a href="{{url}}"{{else}}<a href="{{url}}">closed</a>{{/if}}';
-            var expSecureHbs = expressSecureHandlebars.create();
-            var t1 = expSecureHbs.compileTemplate(template);
 
-            var expHbs = expressHandlebars.create();
-            var t2 = expHbs.compileTemplate(template);
+        it("empty template test", function() {
+            expect(new expressSecureHandlebars.create().handlebars.compile('')(data)).to.be.equal('');
+        });
+
+        var template = '{{#if url}}<a href="{{url}}"{{else}}<a href="{{url}}">closed</a>{{/if}}';
+        it("handlebars fallback on compile error test", function() {
+            var t1 = expressSecureHandlebars.create().handlebars.compile(template);
+            var t2 = expressHandlebars.create().handlebars.compile(template);
+
             expect(t1(data)).to.be.equal(t2(data));
         });
 
-       it("Express Secure Handlebars compileTemplate test", function() {
-            var template = '<a href="{{url}}">closed</a>';
-            var expSecureHbs = expressSecureHandlebars.create();
-            var t1 = expSecureHbs.compileTemplate(template);
+        it("handlebars fallback on precompile error test", function() {
+            var templateSpec1 = expressSecureHandlebars.create().handlebars.precompile(template);
+            var templateSpec2 = expressHandlebars.create().handlebars.precompile(template);
+            var t1 = handlebars.template(eval('(' + templateSpec1 + ')'));
+            var t2 = handlebars.template(eval('(' + templateSpec2 + ')'));
 
-            var expHbs = expressHandlebars.create();
-            var t2 = expHbs.compileTemplate(template);
+            expect(t1(data)).to.be.equal(t2(data));
+        });
+
+       it("handlebars compile test", function() {
+            var template = '<a href="{{url}}">closed</a>';
+            var t1 = expressSecureHandlebars.create().handlebars.compile(template);
+            var t2 = expressHandlebars.create().handlebars.compile(template);
+
             expect(t1(data)).not.to.be.equal(t2(data));
         });
     });


### PR DESCRIPTION
Motivation: https://github.com/ericf/express-handlebars/pull/105 is going to break the public API
An equivalent compile/precompile functions are now made "protected"

Hence, we should directly override the compile/precompile functions of Handlebars, and made the patched Handlebars a parameter of express-handlebars. In view of this, I'm separating the necessary patches to secure-handlebars.js, which can later be forked and made standalone for a new package secure-handlebars.

But anyway, the following changes can work well with both the current version of express-handlebars, and its forthcoming PR 105. And in this particular change, we're able to make way for handlebars 3.0 directly.