### PR TITLE
override EH.render to pass the filename to SH

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-secure-handlebars",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "licenses": [
     {
       "type": "BSD",
@@ -38,8 +38,8 @@
   "dependencies": {
     "express-handlebars": "^2.0.1",
     "handlebars": "^3.0.3",
-    "secure-handlebars": "^1.1.0",
-    "xss-filters": "^1.2.2"
+    "secure-handlebars": "^1.1.1",
+    "xss-filters": "^1.2.4"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",

--- a/src/express-secure-handlebars.js
+++ b/src/express-secure-handlebars.js
@@ -37,5 +37,22 @@ function exphbs(config) {
 }
 
 function create(config) {
-    return new ExpressSecureHandlebars(config);
+
+    /* passing the partialsDir to the secure-handlebars by using the config.compilerOptions */
+    config || (config = {});
+
+    return overrideEH(new ExpressSecureHandlebars(config));
+}
+
+function overrideEH(secureExpHbs) {
+    var r = secureExpHbs.render;
+
+    /* this function is the entry point of parent template file */
+    secureExpHbs.render = function (filePath, context, options) {
+        this.compilerOptions || (this.compilerOptions = {});
+        this.compilerOptions.processingFile = filePath;
+        return r.call(this, filePath, context, options);
+    };
+
+    return secureExpHbs;
 }

--- a/tests/unit/run-express-secure-handlebars.js
+++ b/tests/unit/run-express-secure-handlebars.js
@@ -11,6 +11,7 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
 
     require("mocha");
     var expect = require('expect.js'),
+        path = require('path'),
         expressHandlebars = require('express-handlebars'),
         expressSecureHandlebars = require('../../src/express-secure-handlebars.js'),
         handlebars = require('handlebars');
@@ -71,12 +72,21 @@ Authors: Nera Liu <neraliu@yahoo-inc.com>
             expect(t1(data)).to.be.equal(t2(data));
         });
 
-       it("handlebars compile test", function() {
+        it("handlebars compile test", function() {
             var template = '<a href="{{url}}">closed</a>';
             var t1 = expressSecureHandlebars.create().handlebars.compile(template);
             var t2 = expressHandlebars.create().handlebars.compile(template);
 
             expect(t1(data)).not.to.be.equal(t2(data));
+        });
+
+        it("handlebars getTemplate test", function() {
+            var templateFile = path.resolve("views/yd.hbs");
+            var expSecureHbs = expressSecureHandlebars.create();
+            expSecureHbs.render(templateFile);
+            expect(expSecureHbs.compilerOptions).to.be.ok();
+            expect(expSecureHbs.compilerOptions.processingFile).to.be.ok();
+            expect(expSecureHbs.compilerOptions.processingFile).to.be.match(/yd\.hbs/);
         });
     });
 


### PR DESCRIPTION
- bump up the version
- override render function to pass processing file to secure-handlebars