### PR TITLE
Updated dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,48 @@
+{
+  "name": "express-secure-handlebars",
+  "version": "2.1.1",
+  "dependencies": {
+    "handlebars": {
+      "version": "3.0.3"
+    },
+    "object.assign": {
+      "version": "4.0.3"
+    },
+    "promise": {
+      "version": "7.0.3"
+    },
+    "secure-handlebars": {
+      "version": "1.2.1"
+    },
+    "xss-filters": {
+      "version": "1.2.7"
+    },
+    "express-handlebars": {
+      "version": "2.0.1",
+      "from": "express-handlebars@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-2.0.1.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "from": "glob@>=5.0.0 <6.0.0"
+        },
+        "graceful-fs": {
+          "version": "4.1.6",
+          "from": "graceful-fs@4.1.6"
+        },
+        "handlebars": {
+          "version": "3.0.3",
+          "from": "handlebars@>=3.0.0 <4.0.0"
+        },
+        "object.assign": {
+          "version": "1.1.1",
+          "from": "object.assign@>=1.1.1 <2.0.0"
+        },
+        "promise": {
+          "version": "6.1.0",
+          "from": "promise@>=6.0.0 <7.0.0"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-secure-handlebars",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "licenses": [
     {
       "type": "BSD",

--- a/package.json
+++ b/package.json
@@ -38,22 +38,22 @@
   "dependencies": {
     "express-handlebars": "^2.0.1",
     "handlebars": "^3.0.3",
-    "object.assign": "^3.0.1",
+    "object.assign": "^4.0.3",
     "promise": "^7.0.3",
-    "secure-handlebars": "^1.1.1",
-    "xss-filters": "^1.2.4"
+    "secure-handlebars": "^1.2.1",
+    "xss-filters": "^1.2.7"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",
     "express": "^4.12.*",
-    "grunt": "^0.4.5",
-    "grunt-cli": "0.1.*",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-jshint": "^0.11.0",
-    "grunt-mocha-istanbul": "^2.3.0",
-    "mocha": "^2.3.4",
+    "grunt": "^1.0.1",
+    "grunt-cli": "1.2.*",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-mocha-istanbul": "^5.0.2",
+    "mocha": "^3.0.2",
     "istanbul": "^0.4.0",
-    "supertest": "^0.15.0"
+    "supertest": "^2.0.0"
   },
   "main": "./src/express-secure-handlebars.js",
   "bugs": {


### PR DESCRIPTION
- updated dependencies
- lock down the graceful-fs version in express-handlebars

@neraliu @maditya 
